### PR TITLE
When there is a new version of the Saga and there is an old version running, the load state of the Saga may throw, leaving a reminder to restart the SagaSaga indefinitely. This PR fixes it by canceling potential leftover reminders.

### DIFF
--- a/Sagaway/CorruptedSagaStateException.cs
+++ b/Sagaway/CorruptedSagaStateException.cs
@@ -1,6 +1,6 @@
 ﻿namespace Sagaway;
 
-class CorruptedSagaStateException : Exception
+public class CorruptedSagaStateException : Exception
 {
     public CorruptedSagaStateException(string message) : base(message)
     {

--- a/Sagaway/CorruptedSagaStateException.cs
+++ b/Sagaway/CorruptedSagaStateException.cs
@@ -1,0 +1,12 @@
+﻿namespace Sagaway;
+
+class CorruptedSagaStateException : Exception
+{
+    public CorruptedSagaStateException(string message) : base(message)
+    {
+    }
+
+    public CorruptedSagaStateException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/Sagaway/Saga.cs
+++ b/Sagaway/Saga.cs
@@ -342,8 +342,6 @@ public partial class Saga<TEOperations> : ISagaReset, ISaga<TEOperations> where 
     {
         try
         {
-
-
             var json = await _sagaSupportOperations.LoadSagaAsync(SagaStateName);
 
             //log the json as readable text

--- a/Sagaway/Saga.cs
+++ b/Sagaway/Saga.cs
@@ -340,47 +340,79 @@ public partial class Saga<TEOperations> : ISagaReset, ISaga<TEOperations> where 
     //load the state of the saga, if there is no state, it is a new saga
     private async Task<bool> LoadStateAsync()
     {
-        var json = await _sagaSupportOperations.LoadSagaAsync(SagaStateName);
-
-        //log the json as readable text
-        _logger.LogDebug($"On loading state: Saga {SagaStateName} state: {json}");
-
-        if (json is null || json.Count == 0)
+        try
         {
-            _logger.LogInformation($"State {SagaStateName} is not found in persistence store, Assuming first run.");
-            return true;
-        }
 
-        var uniqueId = json["sagaUniqueId"]?.GetValue<string>();
 
-        _sagaUniqueId = uniqueId!;
-        _done = json["done"]?.GetValue<bool>() ?? false;
-        _isReverting = json["isReverting"]?.GetValue<bool>() ?? false;
-        _hasFailedReported = json["hasFailedReported"]?.GetValue<bool>() ?? false;
+            var json = await _sagaSupportOperations.LoadSagaAsync(SagaStateName);
 
-        _stepRecorder.Length = 0;
-        _stepRecorder.Append(json["stepRecorder"]?.GetValue<string>() ?? string.Empty);
-        _stepRecorder.AppendLine("The Saga is activated.");
-        foreach (var operation in _operations)
-        {
-            operation.LoadState(json);
-        }
+            //log the json as readable text
+            _logger.LogDebug($"On loading state: Saga {SagaStateName} state: {json}");
 
-        var telemetryStateStore = json["telemetryStateStore"]?.GetValue<string>() ?? string.Empty;
-        var telemetryStatePairs = telemetryStateStore.Split('|', StringSplitOptions.RemoveEmptyEntries);
-        
-        _telemetryStateStore.Clear();
-        foreach (var pair in telemetryStatePairs)
-        {
-            var keyValue = pair.Split(',', StringSplitOptions.RemoveEmptyEntries);
-            if (keyValue.Length == 2)
+            if (json is null || json.Count == 0)
             {
-                _telemetryStateStore[keyValue[0]] = keyValue[1];
+                _logger.LogInformation($"State {SagaStateName} is not found in persistence store, Assuming first run.");
+                return true;
             }
-        }
 
-        CheckForCompletion();
-        return false; //new saga
+            var uniqueId = json["sagaUniqueId"]?.GetValue<string>();
+
+            _sagaUniqueId = uniqueId!;
+            _done = json["done"]?.GetValue<bool>() ?? false;
+            _isReverting = json["isReverting"]?.GetValue<bool>() ?? false;
+            _hasFailedReported = json["hasFailedReported"]?.GetValue<bool>() ?? false;
+
+            _stepRecorder.Length = 0;
+            _stepRecorder.Append(json["stepRecorder"]?.GetValue<string>() ?? string.Empty);
+            _stepRecorder.AppendLine("The Saga is activated.");
+            foreach (var operation in _operations)
+            {
+                operation.LoadState(json);
+            }
+
+            var telemetryStateStore = json["telemetryStateStore"]?.GetValue<string>() ?? string.Empty;
+            var telemetryStatePairs = telemetryStateStore.Split('|', StringSplitOptions.RemoveEmptyEntries);
+
+            _telemetryStateStore.Clear();
+            foreach (var pair in telemetryStatePairs)
+            {
+                var keyValue = pair.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                if (keyValue.Length == 2)
+                {
+                    _telemetryStateStore[keyValue[0]] = keyValue[1];
+                }
+            }
+
+            CheckForCompletion();
+            return false; //new saga
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, $"Error loading saga state {SagaStateName}");
+
+            await CancelOperationRemindersAsync();
+            throw new CorruptedSagaStateException("Error loading Saga State, see inner exception. Important, check this problem, it can hurt reliability since a Saga process may stop in the middle!", ex);
+        }
+    }
+
+    private async Task CancelOperationRemindersAsync()
+    {
+         _logger.LogInformation($"Trying to cancel all reminders for saga {_sagaUniqueId}");
+
+
+         foreach (var operation in _operations)
+         {
+             try
+             {
+                 await operation.CancelPossibleReminderIfOnAsync();
+             }
+
+             catch (Exception e)
+             {
+                 _logger.LogWarning(e,
+                     $"Error trying to cancel reminder for operation {operation.Operation.Operation} as a clean operation to prevent endless loop");
+             }
+         }
     }
 
     private async Task StoreStateAsync()

--- a/Sagaway/SagaAction.cs
+++ b/Sagaway/SagaAction.cs
@@ -123,9 +123,9 @@ namespace Sagaway
                 }
             }
             
-            public async Task CancelReminderIfOnAsync()
+            public async Task CancelReminderIfOnAsync(bool forceCancel = false)
             {
-                if (_isReminderOn)
+                if (_isReminderOn || forceCancel)
                 {
                     _logger.LogInformation($"Canceling old reminder {ReminderName} for {OperationName}");
                     _isReminderOn = false;

--- a/Sagaway/SagaOperationExecution.cs
+++ b/Sagaway/SagaOperationExecution.cs
@@ -1,167 +1,177 @@
 ﻿using Microsoft.Extensions.Logging;
 using System.Text.Json.Nodes;
 
-namespace Sagaway
+namespace Sagaway;
+
+
+public partial class Saga<TEOperations> where TEOperations : Enum
 {
-
-    public partial class Saga<TEOperations> where TEOperations : Enum
+    internal class SagaOperationExecution
     {
-        internal class SagaOperationExecution
+        #region Transient State - built on each activation
+
+        private readonly Saga<TEOperations> _saga;
+        private IReadOnlyList<SagaOperationExecution>? _precondition;
+        private readonly ILogger _logger;
+
+        #endregion //Transient State - built on each activation
+
+        #region Persistent State - kept in the state store
+
+        private readonly SagaDoAction _sagaDoAction;
+        private readonly OnActionFailure _sagaRevertAction;
+        private SagaAction _currentAction;
+        private bool _started;
+
+        #endregion //Persistent State - kept in the state store
+
+
+        public SagaOperationExecution(Saga<TEOperations> saga, SagaOperation operation, ILogger logger)
         {
-            #region Transient State - built on each activation
+            _saga = saga;
+            Operation = operation;
+            _logger = logger;
 
-            private readonly Saga<TEOperations> _saga;
-            private IReadOnlyList<SagaOperationExecution>? _precondition;
-            private readonly ILogger _logger;
+            _sagaDoAction = new SagaDoAction(saga, operation, logger);
+            _sagaRevertAction = new OnActionFailure(saga, operation, logger);
+            _currentAction = _sagaDoAction;
+        }
 
-            #endregion //Transient State - built on each activation
+        public SagaOperation Operation { get; }
 
-            #region Persistent State - kept in the state store
+        public void SetDependencies(IReadOnlyList<SagaOperationExecution> precondition)
+        {
+            _precondition = precondition;
+        }
 
-            private readonly SagaDoAction _sagaDoAction;
-            private readonly OnActionFailure _sagaRevertAction;
-            private SagaAction _currentAction;
-            private bool _started;
+        //the operation has been executed successfully and the saga operation is completed
+        public bool Succeeded => _sagaDoAction.Succeeded;
 
-            #endregion //Persistent State - kept in the state store
+        //the operation has been executed and failed with all retries, but not yet reverted
+        public bool Failed => _sagaDoAction.Failed;
 
+        //the operation has been executed and reverted with all retries
+        public bool Reverted => _sagaRevertAction.Succeeded;
 
-            public SagaOperationExecution(Saga<TEOperations> saga, SagaOperation operation, ILogger logger)
+        //the operation has been executed and failed with all retries and failed to revert with all retries
+        public bool RevertFailed => _sagaRevertAction.Failed;
+
+        private bool InProgress => !Succeeded && Reverted && !RevertFailed;
+
+        public bool CanExecute => (_started && InProgress) ||
+                                  !_started && ((_precondition == null) ||
+                                                !_started && _precondition.All(o => o.Succeeded));
+
+        public bool NotStarted => !_started;
+
+        protected void LogAndRecord(string message)
+        {
+            _logger.LogInformation(message);
+            _saga.RecordMessage(message);
+        }
+
+        public async Task StartExecuteAsync()
+        {
+            if (_started)
+                return;
+
+            _started = true;
+            await _currentAction.ExecuteAsync();
+        }
+
+        public async Task RevertAsync()
+        {
+            _currentAction = _sagaRevertAction;
+            await _currentAction.CancelReminderIfOnAsync();
+
+            if (Reverted || RevertFailed)
+                return;
+
+            await _sagaRevertAction.ExecuteAsync();
+        }
+
+        public async Task InformSuccessOperationAsync()
+        {
+            //since Inform comes from the user of the saga, do inform may come after we start reverting
+            if (_currentAction == _sagaDoAction)
             {
-                _saga = saga;
-                Operation = operation;
-                _logger = logger;
-                
-                _sagaDoAction = new SagaDoAction(saga, operation, logger);
-                _sagaRevertAction = new OnActionFailure(saga, operation, logger);
-                _currentAction = _sagaDoAction;
+                await _sagaDoAction.InformSuccessOperationAsync();
             }
+        }
 
-            public SagaOperation Operation { get; }
-
-            public void SetDependencies(IReadOnlyList<SagaOperationExecution> precondition)
+        public async Task InformSuccessUndoOperationAsync()
+        {
+            //since Inform comes from the user of the saga, an undo inform may come not in order
+            if (_currentAction == _sagaRevertAction)
             {
-                _precondition = precondition;
+                await _sagaRevertAction.InformSuccessOperationAsync();
             }
+        }
 
-            //the operation has been executed successfully and the saga operation is completed
-            public bool Succeeded => _sagaDoAction.Succeeded;
-            //the operation has been executed and failed with all retries, but not yet reverted
-            public bool Failed => _sagaDoAction.Failed;
-            //the operation has been executed and reverted with all retries
-            public bool Reverted => _sagaRevertAction.Succeeded;
-            //the operation has been executed and failed with all retries and failed to revert with all retries
-            public bool RevertFailed => _sagaRevertAction.Failed;
-
-            private bool InProgress => !Succeeded && Reverted && !RevertFailed;
-
-            public bool CanExecute => (_started && InProgress) || !_started && ((_precondition == null) || !_started && _precondition.All(o => o.Succeeded));
-
-            public bool NotStarted => !_started;
-
-            protected void LogAndRecord(string message)
+        public async Task InformFailureOperationAsync(bool failFast)
+        {
+            //since Inform comes from the user of the saga, do inform may come after we start reverting
+            if (_currentAction == _sagaDoAction)
             {
-                _logger.LogInformation(message);
-                _saga.RecordMessage(message);
+                await _sagaDoAction.InformFailureOperationAsync(failFast);
             }
-            
-            public async Task StartExecuteAsync()
+        }
+
+        public async Task InformFailureUndoOperationAsync()
+        {
+            //since Inform comes from the user of the saga, an undo inform may come not in order
+            if (_currentAction == _sagaRevertAction)
             {
-                if (_started)
-                    return;
-                
-                _started = true;
-                await _currentAction.ExecuteAsync();
+                await _sagaRevertAction.InformFailureOperationAsync(false);
             }
-            
-            public async Task RevertAsync()
-            {
-                _currentAction = _sagaRevertAction;
-                await _currentAction.CancelReminderIfOnAsync();
+        }
 
-                if (Reverted || RevertFailed)
-                    return;
+        public void MarkSucceeded()
+        {
+            _sagaDoAction.MarkSucceeded();
+        }
 
-                await _sagaRevertAction.ExecuteAsync();
-            }
+        public void MarkReverted()
+        {
+            _sagaRevertAction.MarkSucceeded();
+        }
 
-            public async Task InformSuccessOperationAsync()
-            {
-                //since Inform comes from the user of the saga, do inform may come after we start reverting
-                if (_currentAction == _sagaDoAction)
-                {
-                    await _sagaDoAction.InformSuccessOperationAsync();
-                }
-            }
+        public async Task OnReminderAsync()
+        {
+            await _currentAction.OnReminderAsync();
+        }
 
-            public async Task InformSuccessUndoOperationAsync()
-            {
-                //since Inform comes from the user of the saga, an undo inform may come not in order
-                if (_currentAction == _sagaRevertAction)
-                {
-                    await _sagaRevertAction.InformSuccessOperationAsync();
-                }
-            }
+        public void StoreState(JsonObject json)
+        {
+            var op = Operation.Operation.ToString();
+            json[op] = new JsonObject();
+            json[op]!["started"] = _started;
+            json[op]!["IsCurrentOperationRevert"] = _currentAction == _sagaRevertAction;
 
-            public async Task InformFailureOperationAsync(bool failFast)
-            {
-                //since Inform comes from the user of the saga, do inform may come after we start reverting
-                if (_currentAction == _sagaDoAction)
-                {
-                    await _sagaDoAction.InformFailureOperationAsync(failFast);
-                }
-            }
+            var jsonDo = new JsonObject();
+            json[op + "Do"] = jsonDo;
+            _sagaDoAction.StoreState(jsonDo);
 
-            public async Task InformFailureUndoOperationAsync()
-            {
-                //since Inform comes from the user of the saga, an undo inform may come not in order
-                if (_currentAction == _sagaRevertAction)
-                {
-                    await _sagaRevertAction.InformFailureOperationAsync(false);
-                }
-            }
+            var jsonRevert = new JsonObject();
+            json[op + "Revert"] = jsonRevert;
+            _sagaRevertAction.StoreState(jsonRevert);
+        }
 
-            public void MarkSucceeded()
-            {
-                _sagaDoAction.MarkSucceeded();
-            }
-
-            public void MarkReverted()
-            {
-                _sagaRevertAction.MarkSucceeded();
-            }
-
-            public async Task OnReminderAsync()
-            {
-                await _currentAction.OnReminderAsync();
-            }
-
-            public void StoreState(JsonObject json)
+        public void LoadState(JsonObject json)
+        {
+            try
             {
                 var op = Operation.Operation.ToString();
-                json[op] = new JsonObject();
-                json[op]!["started"] = _started;
-                json[op]!["IsCurrentOperationRevert"] = _currentAction == _sagaRevertAction;
-
-                var jsonDo = new JsonObject();
-                json[op + "Do"] = jsonDo;
-                _sagaDoAction.StoreState(jsonDo);
-
-                var jsonRevert = new JsonObject();
-                json[op + "Revert"] = jsonRevert;
-                _sagaRevertAction.StoreState(jsonRevert);
-            }
-
-            public void LoadState(JsonObject json)
-            {
-                var op = Operation.Operation.ToString();
-                if (!json.ContainsKey(op)) 
+                if (!json.ContainsKey(op))
                     return;
                 //else
                 var opState = json[op] as JsonObject;
-                _started = opState!["started"]?.GetValue<bool>() ?? throw new Exception("Error when loading state, missing started entry");
-                
-                var isCurrentOperationRevert = opState["IsCurrentOperationRevert"]?.GetValue<bool>() ?? throw new Exception("Error when loading state, missing IsCurrentOperationRevert entry");
+                _started = opState!["started"]?.GetValue<bool>() ??
+                           throw new Exception("Error when loading state, missing started entry");
+
+                var isCurrentOperationRevert = opState["IsCurrentOperationRevert"]?.GetValue<bool>() ??
+                                               throw new Exception(
+                                                   "Error when loading state, missing IsCurrentOperationRevert entry");
                 _currentAction = isCurrentOperationRevert ? _sagaRevertAction : _sagaDoAction;
 
                 var opDoState = json[op + "Do"] as JsonObject;
@@ -170,14 +180,40 @@ namespace Sagaway
                 var opRevertState = json[op + "Revert"] as JsonObject;
                 _sagaRevertAction.LoadState(opRevertState!);
             }
-
-            public string GetStatus()
+            catch (Exception e)
             {
-                if (Succeeded) return "Succeeded";
-                if (Failed) return "Failed";
-                if (Reverted) return "Reverted";
-                if (RevertFailed) return "RevertFailed";
-                return "Not Started";
+                throw new CorruptedSagaStateException("Error when loading operation state", e);
+            }
+        }
+
+        public string GetStatus()
+        {
+            if (Succeeded) return "Succeeded";
+            if (Failed) return "Failed";
+            if (Reverted) return "Reverted";
+            if (RevertFailed) return "RevertFailed";
+            return "Not Started";
+        }
+        
+        // Cancel a reminder of an operation as a cleanup operation for left over reminders
+        public async Task CancelPossibleReminderIfOnAsync()
+        {
+            try
+            {
+                await _sagaDoAction.CancelReminderIfOnAsync(true);
+            }
+            catch (Exception e)
+            {
+                _logger.LogWarning(e, "Error when trying to force canceling a possible do operation reminder");
+            }
+            
+            try
+            {
+                await _sagaRevertAction.CancelReminderIfOnAsync();
+            }
+            catch (Exception e)
+            {
+                _logger.LogWarning("Error when trying to force canceling a possible revert operation reminder", e);
             }
         }
     }


### PR DESCRIPTION
This PR fixes it by canceling potential leftover reminders.

Refactored `LoadStateAsync` in `Saga.cs` to include a `try-catch` block for better error handling, logging, and cancellation of operation reminders. Added `CancelOperationRemindersAsync` to handle reminder cancellations in case of errors.

Modified `CancelReminderIfOnAsync` in `SagaAction.cs` to accept an optional `forceCancel` parameter for more flexible reminder management.

Refactored `SagaOperationExecution` in `SagaOperationExecution.cs` for improved readability and maintainability, including adding exception handling in `LoadState` and a new method `CancelPossibleReminderIfOnAsync`.

Added `CorruptedSagaStateException` in `CorruptedSagaStateException.cs` to represent errors related to corrupted saga states.