### PR TITLE
Add SagawayCallbackFilter and routing extension

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -148,6 +148,27 @@ app.UseSagawayCallbackRouter("reservation-response-queue");
 ```
 The parameter is a Dapr component binding name of the callback. The Sagaway currently supports bindings that call the POST HTTP method. A Pub/Sub Topic is not supported yet for auto-routing.
 
+If you want to reuse the same callback queue for non-actor-related tasks, you can define a custom handler like this:
+
+```csharp
+app.UseSagawayCallbackRouter("reservation-response-queue", async (
+    [FromServices] DaprClient daprClient,
+    [FromServices] ILogger<Program> logger) =>
+{
+    try
+    {
+        logger.LogInformation("Processing custom handler");
+        // your custom handling code
+        return Results.Ok();
+    }
+    catch (Exception)
+    {
+        return Results.Problem();
+    }
+});
+```
+This allows you to handle messages from the same queue for additional purposes, beyond actor method invocations, giving you more flexibility in routing.
+
 Example of such a binding:
 
 ```yaml

--- a/Sagaway.Callback.Router/ISagawayActor.cs
+++ b/Sagaway.Callback.Router/ISagawayActor.cs
@@ -1,7 +1,4 @@
-﻿using System.Text.Json.Nodes;
-using Dapr.Client.Autogen.Grpc.v1;
-
-namespace Sagaway.Callback.Router;
+﻿namespace Sagaway.Callback.Router;
 
 public interface ISagawayActor : Dapr.Actors.IActor
 {

--- a/Sagaway.Callback.Router/SagawayCallbackFilter.cs
+++ b/Sagaway.Callback.Router/SagawayCallbackFilter.cs
@@ -1,0 +1,60 @@
+﻿using System.Text.Json.Nodes;
+using Dapr.Actors;
+using Dapr.Actors.Client;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Sagaway.Callback.Router;
+
+internal class SagawayCallbackFilter : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        var httpRequest = context.HttpContext.Request;
+        var logger = context.HttpContext.RequestServices.GetRequiredService<ILogger<ISagawayActor>>();
+        var actorProxyFactory = context.HttpContext.RequestServices.GetRequiredService<IActorProxyFactory>();
+
+        var payload = await JsonNode.ParseAsync(httpRequest.Body);
+        if (payload is null)
+        {
+            logger.LogError("Payload is null or empty.");
+            return await next(context);
+        }
+
+        var methodName = httpRequest.Headers["x-sagaway-dapr-callback-method-name"].FirstOrDefault();
+        if (string.IsNullOrEmpty(methodName))
+        {
+            logger.LogError("x-sagaway-callback-method-name header is missing or empty.");
+            return await next(context);
+        }
+
+        var actorId = httpRequest.Headers["x-sagaway-dapr-actor-id"].FirstOrDefault();
+        if (string.IsNullOrEmpty(actorId))
+        {
+            logger.LogError("x-sagaway-dapr-actor-id header is missing or empty.");
+            return await next(context);
+        }
+
+        var actorTypeName = httpRequest.Headers["x-sagaway-dapr-actor-type"].FirstOrDefault();
+        if (string.IsNullOrEmpty(actorTypeName))
+        {
+            logger.LogError("x-sagaway-dapr-actor-type header is missing or empty.");
+            return await next(context);
+        }
+
+        try
+        {
+            var proxy = actorProxyFactory.CreateActorProxy<ISagawayActor>(new ActorId(actorId), actorTypeName);
+            await proxy.DispatchCallbackAsync(payload.ToJsonString(), methodName);
+            logger.LogInformation("Dispatched callback to {ActorTypeName} for method {MethodName} with Actor ID {ActorId}", actorTypeName, methodName, actorId);
+
+            return Results.Ok();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error dispatching callback to {ActorTypeName} for method {MethodName} with Actor ID {ActorId}", actorTypeName, methodName, actorId);
+            return Results.Ok();
+        }
+    }
+}

--- a/Sagaway.Callback.Router/WebApplicationSagawayExtension.cs
+++ b/Sagaway.Callback.Router/WebApplicationSagawayExtension.cs
@@ -4,6 +4,7 @@ using Dapr.Actors.Client;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
 
 namespace Sagaway.Callback.Router;
@@ -18,7 +19,7 @@ public static class WebApplicationSagawayExtension
             [FromServices] IActorProxyFactory actorProxyFactory,
             [FromServices] ILogger<ISagawayActor> logger) =>
         {
-           
+
             var methodName = httpRequest.Headers["x-sagaway-dapr-callback-method-name"].FirstOrDefault();
             if (string.IsNullOrEmpty(methodName))
             {
@@ -52,6 +53,12 @@ public static class WebApplicationSagawayExtension
                 logger.LogError(ex, "Error dispatching callback to {ActorTypeName} for method {MethodName} with Actor ID {ActorId}", actorTypeName, methodName, actorId);
                 return Results.Ok();
             }
-        }).ExcludeFromDescription(); 
+        }).ExcludeFromDescription();
+    }
+
+    public static void UseSagawayCallbackRouter(this WebApplication app, string callbackBindingName, Delegate handler)
+    {
+        app.MapPost("/" + callbackBindingName, handler)
+        .AddEndpointFilter<SagawayCallbackFilter>();
     }
 }

--- a/Sagaway.Callback.Router/WebApplicationSagawayExtension.cs
+++ b/Sagaway.Callback.Router/WebApplicationSagawayExtension.cs
@@ -4,7 +4,6 @@ using Dapr.Actors.Client;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
 
 namespace Sagaway.Callback.Router;


### PR DESCRIPTION
explanation from README

- To support auto-routing of a callback message, add the following line:
```csharp
app.UseSagawayCallbackRouter("reservation-response-queue");
```
The parameter is a Dapr component binding name of the callback. The Sagaway currently supports bindings that call the POST HTTP method. A Pub/Sub Topic is not supported yet for auto-routing.

If you want to reuse the same callback queue for non-actor-related tasks, you can define a custom handler like this:

```csharp
app.UseSagawayCallbackRouter("reservation-response-queue", async (
    [FromServices] DaprClient daprClient,
    [FromServices] ILogger<Program> logger) =>
{
    try
    {
        logger.LogInformation("Processing custom handler");
        // your custom handling code
        return Results.Ok();
    }
    catch (Exception)
    {
        return Results.Problem();
    }
});
```
This allows you to handle messages from the same queue for additional purposes, beyond actor method invocations, giving you more flexibility in routing.