### PR TITLE
Publish source links enabled NuGet Packages

### DIFF
--- a/.github/workflows/BuildAndPublishAllNugetPackages.yaml
+++ b/.github/workflows/BuildAndPublishAllNugetPackages.yaml
@@ -1,0 +1,138 @@
+name: Build and Publish All NuGet Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      package_version:
+        description: 'Package version'
+        required: false
+  release:
+    types: [published]
+
+jobs:
+  # Build independent packages first using a matrix
+  build_independent_packages:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project:
+          - Sagaway/Sagaway.csproj
+          - Sagaway.Callback.Propagator/Sagaway.Callback.Propagator.csproj
+          - Sagaway.Callback.Router/Sagaway.Callback.Router.csproj
+    outputs:
+      package_version: ${{ steps.get-version.outputs.package_version }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0  # Ensure full git history for SourceLink
+
+    - name: Setup .NET 8
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Determine Package Version
+      id: get-version
+      run: |
+        if [ "${{ github.event.release.tag_name }}" ]; then
+          version="${{ github.event.release.tag_name }}"
+          if [[ $version == *-* ]]; then
+            echo "##[set-output name=package_version;]$version"
+          else
+            echo "##[set-output name=package_version;]${version##v}"
+          fi
+        else
+          echo "##[set-output name=package_version;]${{ github.event.inputs.package_version }}"
+        fi
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build and Pack Independent Packages
+      run: |
+        dotnet pack ${{ matrix.project }} -c Release \
+          -p:PackageVersion=${{ steps.get-version.outputs.package_version }} \
+          -p:PackageReleaseNotes="See https://raw.githubusercontent.com/alonf/Sagaway/master/.github/README.md" \
+          --include-symbols --include-source -p:SymbolPackageFormat=snupkg
+
+    - name: Upload NuGet Package as Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: independent-packages
+        path: '**/*.nupkg'
+
+  # Build dependent packages using the locally published packages
+  build_dependent_packages:
+    needs: build_independent_packages
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0  # Ensure full git history for SourceLink
+
+    - name: Setup .NET 8
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Download Independent Packages
+      uses: actions/download-artifact@v4
+      with:
+        name: independent-packages
+
+    - name: Setup Local NuGet Feed
+      run: |
+        mkdir -p ./local-nuget
+        cp ./**/*.nupkg ./local-nuget/
+        dotnet nuget add source ./local-nuget --name LocalFeed
+
+    - name: Restore dependencies from local feed
+      run: dotnet restore --source ./local-nuget
+
+    - name: Build and Pack Dependent Packages
+      run: |
+        dotnet pack Sagaway.Hosts.DaprActorHost/Sagaway.Hosts.DaprActorHost.csproj -c Release \
+          -p:PackageVersion=${{ needs.build_independent_packages.outputs.package_version }} \
+          -p:PackageReleaseNotes="See https://raw.githubusercontent.com/alonf/Sagaway/master/.github/README.md" \
+          --include-symbols --include-source -p:SymbolPackageFormat=snupkg
+
+        dotnet pack Sagaway.OpenTelemetry/Sagaway.OpenTelemetry.csproj -c Release \
+          -p:PackageVersion=${{ needs.build_independent_packages.outputs.package_version }} \
+          -p:PackageReleaseNotes="See https://raw.githubusercontent.com/alonf/Sagaway/master/.github/README.md" \
+          --include-symbols --include-source -p:SymbolPackageFormat=snupkg
+
+    - name: Upload Dependent NuGet Package as Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: dependent-packages
+        path: '**/*.nupkg'
+
+  # Publish all packages to NuGet.org
+  publish_to_nuget:
+    needs: [build_independent_packages, build_dependent_packages]
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Download All Packages
+      uses: actions/download-artifact@v4
+      with:
+        name: independent-packages
+
+    - name: Download Dependent Packages
+      uses: actions/download-artifact@v4
+      with:
+        name: dependent-packages
+
+    - name: Publish NuGet Packages
+      run: |
+        dotnet nuget push '**/*.nupkg' --api-key ${{ secrets.NUGET_API_KEY }} \
+          --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+        dotnet nuget push '**/*.snupkg' --api-key ${{ secrets.NUGET_API_KEY }} \
+          --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/PublishSagawayCallbackPropagatorNuGet.yaml
+++ b/.github/workflows/PublishSagawayCallbackPropagatorNuGet.yaml
@@ -6,8 +6,8 @@ on:
       package_version:
         description: 'Package version'
         required: false
-  release:
-    types: [published]
+  # release:
+  #   types: [published]
 
 jobs:
   build:

--- a/.github/workflows/PublishSagawayCallbackRouter.yaml
+++ b/.github/workflows/PublishSagawayCallbackRouter.yaml
@@ -6,8 +6,8 @@ on:
       package_version:
         description: 'Package version'
         required: false
-  release:
-    types: [published]
+  # release:
+  #   types: [published]
 
 jobs:
   build:

--- a/.github/workflows/PublishSagawayDaprActorHost.yaml
+++ b/.github/workflows/PublishSagawayDaprActorHost.yaml
@@ -6,8 +6,8 @@ on:
       package_version:
         description: 'Package version'
         required: false
-  release:
-    types: [published]
+  # release:
+  #   types: [published]
 
 jobs:
   build:

--- a/.github/workflows/PublishSagawayNuGet.yaml
+++ b/.github/workflows/PublishSagawayNuGet.yaml
@@ -6,8 +6,8 @@ on:
       package_version:
         description: 'Package version'
         required: false
-  release:
-    types: [published]
+  # release:
+  #   types: [published]
 
 jobs:
   build:

--- a/.github/workflows/PublishSagawayOpenTelemetryNuGet.yaml
+++ b/.github/workflows/PublishSagawayOpenTelemetryNuGet.yaml
@@ -6,8 +6,8 @@ on:
       package_version:
         description: 'Package version'
         required: false
-  release:
-    types: [published]
+  # release:
+  #   types: [published]
 
 jobs:
   build:

--- a/Sagaway.Callback.Propagator/Sagaway.Callback.Propagator.csproj
+++ b/Sagaway.Callback.Propagator/Sagaway.Callback.Propagator.csproj
@@ -18,6 +18,15 @@
     <PackageIcon>assets/package-icon.png</PackageIcon>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <EnableSourceLink>true</EnableSourceLink>
+    <DebugType>portable</DebugType>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IncludeSource>true</IncludeSource>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="../assets/package-icon.png" Pack="true" PackagePath="assets/" />
   </ItemGroup>
@@ -32,5 +41,9 @@
   <ItemGroup>
     <PackageReference Include="Dapr.AspNetCore" Version="1.14.0" />
     <PackageReference Include="Dapr.Client" Version="1.14.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/Sagaway.Callback.Router/Sagaway.Callback.Router.csproj
+++ b/Sagaway.Callback.Router/Sagaway.Callback.Router.csproj
@@ -18,6 +18,15 @@
     <PackageIcon>assets/package-icon.png</PackageIcon>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <EnableSourceLink>true</EnableSourceLink>
+    <DebugType>portable</DebugType>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IncludeSource>true</IncludeSource>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="../assets/package-icon.png" Pack="true" PackagePath="assets/" />
   </ItemGroup>
@@ -32,6 +41,10 @@
   <ItemGroup>
     <PackageReference Include="Dapr.Client" Version="1.14.0" />
         <PackageReference Include="Dapr.Actors.AspNetCore" Version="1.14.0" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Polly" Version="8.4.1" />
   </ItemGroup>
 

--- a/Sagaway.Hosts.DaprActorHost/Sagaway.Hosts.DaprActorHost.csproj
+++ b/Sagaway.Hosts.DaprActorHost/Sagaway.Hosts.DaprActorHost.csproj
@@ -22,6 +22,15 @@
     <!-- Default to false; override in CI/CD or command line -->
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <EnableSourceLink>true</EnableSourceLink>
+    <DebugType>portable</DebugType>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IncludeSource>true</IncludeSource>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="../assets/package-icon.png" Pack="true" PackagePath="assets/" />
   </ItemGroup>
@@ -37,6 +46,10 @@
   <ItemGroup>
     <PackageReference Include="Dapr.Actors.AspNetCore" Version="1.14.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <!-- Conditionally include Project References -->

--- a/Sagaway.OpenTelemetry/Sagaway.OpenTelemetry.csproj
+++ b/Sagaway.OpenTelemetry/Sagaway.OpenTelemetry.csproj
@@ -14,6 +14,15 @@
     <!-- Default to false; override in CI/CD or command line -->
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <EnableSourceLink>true</EnableSourceLink>
+    <DebugType>portable</DebugType>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IncludeSource>true</IncludeSource>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="../assets/package-icon.png" Pack="true" PackagePath="assets/" />
   </ItemGroup>
@@ -26,6 +35,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="OpenTelemetry" Version="1.9.0" />
   </ItemGroup>
 

--- a/Sagaway.sln
+++ b/Sagaway.sln
@@ -64,6 +64,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "gihub", "gihub", "{7D12D337
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{B962A366-5569-4C6E-AE25-707750522035}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\BuildAndPublishAllNugetPackages.yaml = .github\workflows\BuildAndPublishAllNugetPackages.yaml
 		.github\workflows\BuildAndPushImages.yaml = .github\workflows\BuildAndPushImages.yaml
 		.github\workflows\IntegrationTest.yaml = .github\workflows\IntegrationTest.yaml
 		.github\workflows\PublishSagawayCallbackPropagatorNuGet.yaml = .github\workflows\PublishSagawayCallbackPropagatorNuGet.yaml
@@ -78,7 +79,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "assets", "assets", "{EFADD2
 		assets\ackage-icon.png = assets\ackage-icon.png
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sagaway.IntegrationTests.TestSubSagaCommunicationService", "Sagaway.IntegrationTests\Sagaway.IntegrationTests.TestSubSagaCommunicationService\Sagaway.IntegrationTests.TestSubSagaCommunicationService.csproj", "{D25065BB-282F-47CD-B2EB-4A2181860E7D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sagaway.IntegrationTests.TestSubSagaCommunicationService", "Sagaway.IntegrationTests\Sagaway.IntegrationTests.TestSubSagaCommunicationService\Sagaway.IntegrationTests.TestSubSagaCommunicationService.csproj", "{D25065BB-282F-47CD-B2EB-4A2181860E7D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Sagaway/Sagaway.csproj
+++ b/Sagaway/Sagaway.csproj
@@ -18,6 +18,16 @@
     <PackageIcon>assets/package-icon.png</PackageIcon>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <EnableSourceLink>true</EnableSourceLink>
+    <DebugType>portable</DebugType>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IncludeSource>true</IncludeSource>
+  </PropertyGroup>
+
+
   <ItemGroup>
     <None Include="../assets/package-icon.png" Pack="true" PackagePath="assets/" />
   </ItemGroup>
@@ -31,6 +41,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
#### PR Classification
New feature to streamline the build and publish process for NuGet packages.

#### PR Summary
Introduces a new GitHub Actions workflow for building and publishing all NuGet packages and updates project files for SourceLink and symbol/source inclusion.
- Added `BuildAndPublishAllNugetPackages.yaml` workflow with matrix strategy and local package publishing.
- Commented out `release` trigger in multiple existing workflow files.
- Updated project files (`.csproj`) to include SourceLink and symbol/source properties.
- Modified `Sagaway.sln` to include the new workflow file and correct project type GUID.
