### PR TITLE
Bug fix to ensure HTTP headers are handled in a case-insensitive manner.

### DIFF
--- a/Sagaway.Callback.Propagator/SagawayContextManager.cs
+++ b/Sagaway.Callback.Propagator/SagawayContextManager.cs
@@ -107,17 +107,15 @@ public class SagawayContextManager : ISagawayContextManager
         if (headers == null)
             throw new ArgumentNullException(nameof(headers));
 
-        headers.TryGetValue("x-sagaway-dapr-actor-id", out var actorId);
+        // Create a case-insensitive dictionary based on the provided headers
+        var caseInsensitiveHeaders = new Dictionary<string, string?>(headers, StringComparer.OrdinalIgnoreCase);
 
-        headers.TryGetValue("x-sagaway-dapr-actor-type", out var actorType);
-
-        headers.TryGetValue("x-sagaway-dapr-callback-binding-name", out var callbackBindingName);
-
-        headers.TryGetValue("x-sagaway-dapr-callback-method-name", out var callbackMethodName);
-
-        headers.TryGetValue("x-sagaway-dapr-message-dispatch-time", out var messageDispatchTime);
-
-        headers.TryGetValue("x-sagaway-dapr-custom-metadata", out var customMetadata);
+        caseInsensitiveHeaders.TryGetValue("x-sagaway-dapr-actor-id", out var actorId);
+        caseInsensitiveHeaders.TryGetValue("x-sagaway-dapr-actor-type", out var actorType);
+        caseInsensitiveHeaders.TryGetValue("x-sagaway-dapr-callback-binding-name", out var callbackBindingName);
+        caseInsensitiveHeaders.TryGetValue("x-sagaway-dapr-callback-method-name", out var callbackMethodName);
+        caseInsensitiveHeaders.TryGetValue("x-sagaway-dapr-message-dispatch-time", out var messageDispatchTime);
+        caseInsensitiveHeaders.TryGetValue("x-sagaway-dapr-custom-metadata", out var customMetadata);
 
         return new SagawayContext(actorId, actorType, callbackBindingName, callbackMethodName, messageDispatchTime, customMetadata);
     }

--- a/Sagaway.Callback.Propagator/SagawayContextPropagationHandler.cs
+++ b/Sagaway.Callback.Propagator/SagawayContextPropagationHandler.cs
@@ -15,7 +15,19 @@ public class SagawayContextPropagationHandler : DelegatingHandler
         //propagate callback method name
         if (!string.IsNullOrEmpty(HeaderPropagationMiddleware.SagawayContext.Value?.CallbackMethodName))
             request.Headers.TryAddWithoutValidation("x-sagaway-dapr-callback-method-name", [HeaderPropagationMiddleware.SagawayContext.Value.CallbackMethodName]);
-        
+
+        //propagate message callback binding name
+        if (!string.IsNullOrEmpty(HeaderPropagationMiddleware.SagawayContext.Value?.CallbackBindingName))
+            request.Headers.TryAddWithoutValidation("x-sagaway-dapr-callback-binding-name", [HeaderPropagationMiddleware.SagawayContext.Value.CallbackBindingName]);
+
+        //propagate message dispatch time
+        if (!string.IsNullOrEmpty(HeaderPropagationMiddleware.SagawayContext.Value?.MessageDispatchTime))
+            request.Headers.TryAddWithoutValidation("x-sagaway-dapr-message-dispatch-time", [HeaderPropagationMiddleware.SagawayContext.Value.MessageDispatchTime]);
+
+        //propagate custom metadata
+        if (!string.IsNullOrEmpty(HeaderPropagationMiddleware.SagawayContext.Value?.Metadata))
+            request.Headers.TryAddWithoutValidation("x-sagaway-dapr-custom-metadata", [HeaderPropagationMiddleware.SagawayContext.Value.Metadata]);
+
         return await base.SendAsync(request, cancellationToken);
     }
 }


### PR DESCRIPTION
#### PR Classification
Bug fix to ensure HTTP headers are handled in a case-insensitive manner.

#### PR Summary
The code has been updated to handle HTTP headers case-insensitively by using a new dictionary with `StringComparer.OrdinalIgnoreCase`.
- Created `caseInsensitiveHeaders` dictionary to wrap the original `headers` dictionary.
- Ensured header keys are matched correctly regardless of their case in the `GetSagawayContextFromHeaders` method.
